### PR TITLE
Add Docker build for automated deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+.dockerignore
+.git
+.gitignore
+web/node_modules
+server/node_modules
+web/dist
+server/dist
+scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-bookworm-slim AS builder
+WORKDIR /app
+
+# Install dependencies using npm workspaces
+COPY package*.json ./
+COPY server/package*.json server/
+COPY web/package*.json web/
+RUN npm ci
+
+# Copy source files and build both the frontend and backend
+COPY . .
+RUN npm run build
+
+# Remove development dependencies to slim down the final image
+RUN npm prune --omit=dev
+
+FROM node:20-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Copy the workspace manifests and production node_modules
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/package-lock.json ./
+COPY --from=builder /app/server/package.json server/
+COPY --from=builder /app/web/package.json web/
+COPY --from=builder /app/node_modules ./node_modules
+
+# Copy the compiled server and static frontend assets
+COPY --from=builder /app/server/dist ./server/dist
+COPY --from=builder /app/web/dist ./web/dist
+COPY --from=builder /app/.env.example ./
+
+EXPOSE 8080
+
+CMD ["node", "server/dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ npm run start --prefix server  # Run compiled server serving static assets
 
 The Express server serves `web/dist` in production. Ensure you run `npm run build` before starting the backend.
 
+## Docker deployment
+
+The repository includes a multi-stage Dockerfile that builds the frontend and backend and packages only the production
+dependencies.
+
+1. Copy `.env.example` to `.env` (or prepare your own env file) and fill in the Jellyfin connection details.
+2. Build the image:
+   ```bash
+   docker build -t jellyfin-p2p-watch .
+   ```
+3. Run the container, exposing the HTTP port and passing configuration via environment variables or an env file:
+   ```bash
+   docker run --rm -p 8080:8080 --env-file .env jellyfin-p2p-watch
+   ```
+
+Adjust the published port (`-p host:8080`) or individual environment variables as needed for your deployment setup. The
+container listens on `$PORT` (default `8080`) and serves the compiled static frontend alongside the Node.js backend.
+
 ## SyncPlay-like control flow
 
 - Clients connect to `/ws` and send `{ type: "join", roomId, userName }`.


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the frontend and backend and runs the compiled server
- add a .dockerignore to keep the build context small
- document how to build and run the container image in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfd89169e883278c5ac9972ed1b318