### PR TITLE
Add GitHub Actions workflow for container-based CD

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -1,0 +1,132 @@
+name: Docker CD
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload dist artifact
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: |
+            server/dist
+            web/dist
+          if-no-files-found: ignore
+          retention-days: 3
+
+  publish-image:
+    name: Publish image
+    needs: ci
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/jellyfin-p2p-watch
+          tags: |
+            type=sha,format=long,prefix=sha-
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+
+  deploy:
+    name: Deploy
+    needs: publish-image
+    if: github.event_name == 'push'
+    runs-on:
+      - self-hosted
+      - linux
+      - docker
+    environment:
+      name: production
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure compose context
+        id: compose
+        env:
+          COMPOSE_FILE_PATH: ${{ secrets.COMPOSE_FILE_PATH }}
+        run: |
+          if [ -z "${COMPOSE_FILE_PATH}" ]; then
+            echo "COMPOSE_FILE_PATH secret must be provided" >&2
+            exit 1
+          fi
+          COMPOSE_DIR=$(dirname "${COMPOSE_FILE_PATH}")
+          COMPOSE_FILE=$(basename "${COMPOSE_FILE_PATH}")
+          echo "COMPOSE_DIR=${COMPOSE_DIR}" >> "$GITHUB_ENV"
+          echo "COMPOSE_FILE_NAME=${COMPOSE_FILE}" >> "$GITHUB_ENV"
+
+      - name: Set compose project name
+        if: ${{ secrets.COMPOSE_PROJECT_NAME != '' }}
+        run: echo "COMPOSE_PROJECT_NAME=${{ secrets.COMPOSE_PROJECT_NAME }}" >> "$GITHUB_ENV"
+
+      - name: Pull and restart stack
+        run: |
+          cd "${COMPOSE_DIR}"
+          export COMPOSE_FILE="${COMPOSE_DIR}/${COMPOSE_FILE_NAME}"
+          docker compose pull app
+          docker compose up -d app
+          docker compose ps


### PR DESCRIPTION
## Summary
- add Docker-based CI/CD workflow that builds, tests, publishes, and deploys the monorepo through GHCR
- configure publish job for sha/main/latest tags and deployment to self-hosted runner via docker compose

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68cff96751e48327b6a074c4ad8e7c23