### PR TITLE
Switch project docs to Docker Compose workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  app:
+    image: jellyfin-p2p-watch:compose
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    ports:
+      - "${APP_PORT:-8080}:8080"
+    restart: unless-stopped

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-npm run build
+
+if [ "$#" -eq 0 ]; then
+  docker compose build app
+else
+  docker compose build "$@"
+fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-npm run dev
+
+docker compose up --build "$@"


### PR DESCRIPTION
## Summary
- add a docker-compose.yml describing the app service for DockerPult and local runs
- rewrite the README to document the Docker Compose-only workflow and update production notes
- retarget helper scripts to wrap docker compose commands instead of npm

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0075283e48327b1ba78a0a9ee44df