### PR TITLE
Add deploy workflow and document secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,101 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - ci.yml
+    branches:
+      - main
+    types:
+      - completed
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish image
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.image.outputs.name }}
+      tag: ${{ steps.meta.outputs.version }}
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+      TARGET_REF: ${{ github.event_name == 'workflow_run' && format('refs/heads/{0}', github.event.workflow_run.head_branch) || github.ref }}
+      TARGET_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image name
+        id: image
+        run: echo "name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          ref: ${{ env.TARGET_REF }}
+          sha: ${{ env.TARGET_SHA }}
+          tags: |
+            type=sha,format=long,prefix=sha-
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main') || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  remote-deploy:
+    name: Remote deploy
+    needs: publish
+    if: ${{ needs.publish.result == 'success' && secrets.SSH_HOST && secrets.SSH_USER && secrets.SSH_KEY && secrets.DEPLOY_PATH && secrets.GHCR_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@master
+        env:
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          GHCR_USERNAME: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          APP_IMAGE: ${{ format('{0}:{1}', needs.publish.outputs.image, needs.publish.outputs.tag) }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          envs: DEPLOY_PATH,GHCR_USERNAME,GHCR_TOKEN,APP_IMAGE
+          script: |
+            set -euo pipefail
+            docker login ghcr.io -u "${GHCR_USERNAME}" -p "${GHCR_TOKEN}"
+            cd "${DEPLOY_PATH}"
+            git pull --ff-only
+            APP_IMAGE="${APP_IMAGE}" docker compose pull app
+            docker compose up -d app
+            docker image prune -f

--- a/README.md
+++ b/README.md
@@ -103,6 +103,31 @@ Set `APP_PORT` before running Compose if you need a different host port: `APP_PO
 container listens on `$PORT` (default `8080`) and serves the compiled static frontend alongside the Node.js backend built
 inside the image.
 
+## CI/CD automation
+
+The `deploy` GitHub Actions workflow publishes the Docker image to GHCR when the `CI` workflow finishes on `main` or when tags
+matching `v*` are pushed. It reuses the multi-stage Dockerfile and updates remote hosts over SSH when the necessary secrets
+are available.
+
+### Required secrets
+
+Configure the following repository secrets so the workflow can publish images and trigger remote deployments:
+
+- `SSH_HOST` — SSH hostname or IP address of the deployment target.
+- `SSH_USER` — SSH user with permissions to pull the repository and manage Docker.
+- `SSH_KEY` — Private key matching the authorized deploy key on the target host.
+- `DEPLOY_PATH` — Absolute path to the Git repository on the remote server.
+- `GHCR_TOKEN` — Personal access token or fine-grained token with `packages:read` access for `ghcr.io`.
+
+### Image tag format
+
+Every build pushed by the workflow includes the following tags so you can choose the appropriate image reference in Docker
+Compose or other tooling:
+
+- `sha-<full commit SHA>` — immutable reference for the exact commit that triggered the build.
+- `latest` — convenience tag published for the `main` branch and `v*` release tags.
+- `<branch-or-tag>` — sanitized branch name (e.g., `main`) for branch builds or the Git tag name (e.g., `v1.2.3`).
+
 ## SyncPlay-like control flow
 
 - Clients connect to `/ws` and send `{ type: "join", roomId, userName }`.


### PR DESCRIPTION
## Summary
- add a deploy workflow that builds and pushes the container image on CI completion for main or version tags and optionally deploys over SSH
- document the required secrets and image tag conventions in the README

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d011c4e9d883278519e479c077f97e