### PR TITLE
Add Docker CI stage for lint/test/build with artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,50 +5,35 @@ on:
   pull_request:
 
 jobs:
-  quality:
+  container-ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [server, web]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Run CI stage
+        env:
+          BUILDKIT_PROGRESS: plain
+        run: |
+          docker buildx build \
+            --file Dockerfile \
+            --target ci \
+            --output type=local,dest=ci-output \
+            .
 
-      - name: Lint server
-        if: matrix.target == 'server'
-        run: npx eslint "server/src/**/*.ts"
-
-      - name: Lint web
-        if: matrix.target == 'web'
-        run: npx eslint "web/src/**/*.ts"
-
-      - name: Build
-        run: npm run build --prefix ${{ matrix.target }}
-
-      - name: Test
-        run: npm run test --workspace ${{ matrix.target }} -- --coverage --coverage.reporter=lcov
-
-      - name: Upload coverage and test report
+      - name: Upload CI artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target }}-coverage
-          path: |
-            ${{ matrix.target }}/coverage/lcov.info
-            ${{ matrix.target }}/vitest-report.xml
-          if-no-files-found: ignore
+          name: ci-artifacts
+          path: ci-output/ci-artifacts
+          if-no-files-found: warn
 
   docker:
-    needs: quality
+    needs: container-ci
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20-bookworm-slim AS builder
+FROM node:20-bookworm-slim AS base
 WORKDIR /app
 
 # Install dependencies using npm workspaces
@@ -8,6 +8,29 @@ COPY package*.json ./
 COPY server/package*.json server/
 COPY web/package*.json web/
 RUN npm ci
+
+FROM base AS ci
+
+# Copy source files for linting, testing, and building
+COPY . .
+
+RUN npm run lint \
+  && npm run ci:test \
+  && npm run build
+
+RUN mkdir -p /ci-artifacts \
+  && for workspace in server web; do \
+    if [ -d "$workspace/coverage" ]; then \
+      mkdir -p "/ci-artifacts/$workspace" \
+        && cp -r "$workspace/coverage" "/ci-artifacts/$workspace/coverage"; \
+    fi; \
+    if [ -f "$workspace/vitest-report.xml" ]; then \
+      mkdir -p "/ci-artifacts/$workspace" \
+        && cp "$workspace/vitest-report.xml" "/ci-artifacts/$workspace/"; \
+    fi; \
+  done
+
+FROM base AS build
 
 # Copy source files and build both the frontend and backend
 COPY . .
@@ -21,16 +44,16 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 # Copy the workspace manifests and production node_modules
-COPY --from=builder /app/package.json ./
-COPY --from=builder /app/package-lock.json ./
-COPY --from=builder /app/server/package.json server/
-COPY --from=builder /app/web/package.json web/
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./
+COPY --from=build /app/package-lock.json ./
+COPY --from=build /app/server/package.json server/
+COPY --from=build /app/web/package.json web/
+COPY --from=build /app/node_modules ./node_modules
 
 # Copy the compiled server and static frontend assets
-COPY --from=builder /app/server/dist ./server/dist
-COPY --from=builder /app/web/dist ./web/dist
-COPY --from=builder /app/.env.example ./
+COPY --from=build /app/server/dist ./server/dist
+COPY --from=build /app/web/dist ./web/dist
+COPY --from=build /app/.env.example ./
 
 EXPOSE 8080
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "npm run build --prefix web && npm run build --prefix server",
     "lint": "eslint \"server/src/**/*.ts\" \"web/src/**/*.ts\"",
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\"",
-    "test": "npm run test --workspaces"
+    "test": "npm run test --workspaces",
+    "ci:test": "npm run test --workspaces -- --coverage --coverage.reporter=lcov"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.21.0",


### PR DESCRIPTION
## Summary
- extend the Dockerfile with reusable base, build, and ci stages; run lint/test/build in the ci stage and collect coverage artifacts while keeping the production image slim
- add an npm script for coverage-enabled workspace tests
- update the CI workflow to build the ci stage via buildx and upload exported artifacts

## Testing
- npm run lint
- npm run ci:test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d01ce9e1848327ab835e2085228be1